### PR TITLE
ci: release-it conf path for uv version bump

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -4,7 +4,7 @@
   ],
   "hooks": {
     "after:bump": [
-      "docker run --rm -v $(pwd):$(pwd) -w $(pwd) ghcr.io/astral-sh/uv:0.9.11-python3.12-trixie-slim uv version ${version}"
+      "docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ghcr.io/astral-sh/uv:0.9.11-python3.12-trixie-slim uv version ${version}"
     ]
   },
   "plugins": {


### PR DESCRIPTION
Closes #6 

> ## Expected behavior
> 
> Image stages for the uv package successfully build after release-it version bump and tag.
> 
> ## Observed behavior
> 
> Image builds fail due to uv lockfile inconsistency.
> 
> ```bash
> #40 0.293 The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
> #40 ERROR: process "/bin/sh -c uv sync --locked --no-editable --no-install-project" did not complete successfully: exit code: 1
> ```
> 
> ## Proposed resolution
> 
> Instead of configuring release-it to bump the `pyproject.toml` file directly via the file bumper, add a hook configuration to use `uv version` to apply this change, thus keeping the lockfile in sync.