### PR TITLE
ci: fix release-it workflow for hook support

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -87,16 +87,16 @@ jobs:
           path: out/dive.json
   release-it-workflow:
     needs: dive-efficiency
-    uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@0.4.0
+    uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@0.5.2
     with:
       app-id: 1828679 # mender-docker-lifecycle-helper release-it app
       app-environment: Repo release
       # Download dive artifact for assets
       artifact-name: ${{ format('refs/heads/{0}', github.event.repository.default_branch) == github.ref && 'dive_results' || '' }}
-      # Use the file bumper release-it image
-      release-it-image: ghcr.io/rcwbr/release-it-docker-file-bumper:0.8.1
       # Use custom release-it config
       release-it-config: .release-it.json
+      # Use the file bumper release-it image
+      release-it-image: ghcr.io/rcwbr/release-it-docker-file-bumper:0.8.1
     secrets:
       app-secret: ${{ secrets.RELEASE_IT_GITHUB_APP_KEY }} # Secret belonging to the Repo release environment
   pre-commit:

--- a/.release-it.json
+++ b/.release-it.json
@@ -4,7 +4,7 @@
   ],
   "hooks": {
     "after:bump": [
-      "docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ghcr.io/astral-sh/uv:0.9.11-python3.12-trixie-slim uv version ${version}"
+      "docker run --rm -v $(pwd):$(pwd) -w $(pwd) ghcr.io/astral-sh/uv:0.9.11-python3.12-trixie-slim uv version ${version}"
     ]
   },
   "plugins": {


### PR DESCRIPTION
Closes #6 

> ## Expected behavior
> 
> Image stages for the uv package successfully build after release-it version bump and tag.
> 
> ## Observed behavior
> 
> Image builds fail due to uv lockfile inconsistency.
> 
> ```bash
> #40 0.293 The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
> #40 ERROR: process "/bin/sh -c uv sync --locked --no-editable --no-install-project" did not complete successfully: exit code: 1
> ```
> 
> ## Proposed resolution
> 
> Instead of configuring release-it to bump the `pyproject.toml` file directly via the file bumper, add a hook configuration to use `uv version` to apply this change, thus keeping the lockfile in sync.