### PR TITLE
fix: release conf for dive results asset

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -2,6 +2,10 @@
   "extends": [
     "github:rcwbr/release-it-docker/file-bumper#0.8.0"
   ],
+  "github": {
+    "assets": "dive.json",
+    "release": true
+  },
   "hooks": {
     "after:bump": [
       "docker run --rm -v $(pwd):$(pwd) -w $(pwd) ghcr.io/astral-sh/uv:0.9.11-python3.12-trixie-slim uv version ${version}"


### PR DESCRIPTION
Closes #10 

> ## Expected behavior
> 
> Docker Dive results generated by main branch workflows are published by release-it in as release assets.
> 
> ## Observed behavior
> 
> No assets are added.
> 
> ## Proposed resolution
> 
> Restore `.release-it.json` config:
> 
> ```json
>   "github": {
>     "assets": "dive.json",
>     "release": true
>   },
> ```
> 