### PR TITLE
ci: fix docs branch common history

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -166,13 +166,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           ref: docs
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
@@ -185,7 +185,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
           ref: docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Closes #18 

> ## What
> 
> Generate mkdocs of the helper tool, including API docs from docstrings.
> 
> ## Why
> 
> For better user/developer experience.
> 
> ## How
> 
> Add mkdocs config to the project and deployment via CI workflow
> 
