### PR TITLE
ci: docs one checkout with full history

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -168,12 +168,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
-          ref: docs
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Mike


### PR DESCRIPTION
Closes #18 

> ## What
> 
> Generate mkdocs of the helper tool, including API docs from docstrings.
> 
> ## Why
> 
> For better user/developer experience.
> 
> ## How
> 
> Add mkdocs config to the project and deployment via CI workflow
> 