### PR TITLE
ci: docs checkout toggle once cloned

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -172,6 +172,8 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Mike
         run: |
+          git checkout docs
+          git checkout ${{ github.ref_name }}
           git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
           git config --global user.name github-actions[bot]
           pip install -e .


### PR DESCRIPTION
Closes #18 

> ## What
> 
> Generate mkdocs of the helper tool, including API docs from docstrings.
> 
> ## Why
> 
> For better user/developer experience.
> 
> ## How
> 
> Add mkdocs config to the project and deployment via CI workflow
> 