### PR TITLE
docs: mkdocs enable code copy

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,8 +44,10 @@ plugins:
 theme:
   favicon: TODO
   features:
+    - content.code.copy
     - search.highlight
     - search.share
+    - versioning
   icon:
     logo: fontawesome/solid/arrows-turn-to-dots
     repo: fontawesome/brands/github


### PR DESCRIPTION
Closes #18 

> ## What
> 
> Generate mkdocs of the helper tool, including API docs from docstrings.
> 
> ## Why
> 
> For better user/developer experience.
> 
> ## How
> 
> Add mkdocs config to the project and deployment via CI workflow
> 