### PR TITLE
feat: ci deploy only delta aritfacts

### DIFF
--- a/.github/workflows/mender-docker-lifecycle-helper.yaml
+++ b/.github/workflows/mender-docker-lifecycle-helper.yaml
@@ -76,7 +76,7 @@ jobs:
             --device-type ${{ inputs.device-type }} \
             ${{ matrix.delta && '--delta' || '--no-delta' }} \
             ${{ matrix.release && '--release' || '--no-release' }} \
-            ${{ inputs.device-group && format('--device-group {0}', inputs.device-group) || '' }} \
+            ${{ ( ! matrix.delta && inputs.device-group ) && format('--device-group {0}', inputs.device-group) || '' }} \
             ${{ inputs.mender-host && format('--mender-host {0}', inputs.mender-host) || '' }} \
             ${{ inputs.service-images && format('--service-image {0}', join(fromJSON(inputs.service-images), '--service-image')) || '' }} \
             ${{ inputs.service-files && format('--service-file {0}', join(fromJSON(inputs.service-files), '--service-file')) || '' }} \


### PR DESCRIPTION
Closes #13 

> 
> ## Expected behavior
> 
> Successful workflow execution for release tags.
> 
> ## Observed behavior
> 
> ```bash
> [2025-12-10 02:41:29,903] ERROR: Request failed for endpoint api/management/v1/deployments/deployments/group/mender-docker-lifecycle-helper-example: status=409, text={"error":"Invalid deployment definition: there is already an active deployment with the same parameters","request_id":"432ad856-ab73-4731-ab4d-d3128c11b5e7"}, url=https://hosted.mender.io/api/management/v1/deployments/deployments/group/mender-docker-lifecycle-helper-example, headers={'User-Agent': 'python-requests/2.32.4', 'Accept-Encoding': 'gzip, deflate', 'Accept': 'application/json', 'Connection': 'keep-alive', 'Authorization': '***', 'Content-Length': '150', 'Content-Type': 'application/json'}
> Traceback (most recent call last):
>   File "/usr/local/bin/mender-docker-lifecycle-helper", line 8, in <module>
>     sys.exit(main())
>              ^^^^^^
>   File "/usr/local/lib/python3.12/site-packages/mender_docker_lifecycle_helper/mender_docker_lifecycle_helper.py", line 711, in main
>     helper.prep_artifact()
>   File "/usr/local/lib/python3.12/site-packages/mender_docker_lifecycle_helper/mender_docker_lifecycle_helper.py", line 621, in prep_artifact
>     self.deploy_artifact()
>   File "/usr/local/lib/python3.12/site-packages/mender_docker_lifecycle_helper/mender_docker_lifecycle_helper.py", line 568, in deploy_artifact
>     self.call_mender_host_api(
>   File "/usr/local/lib/python3.12/site-packages/mender_docker_lifecycle_helper/mender_docker_lifecycle_helper.py", line 533, in call_mender_host_api
>     r.raise_for_status()
>   File "/usr/local/lib/python3.12/site-packages/requests/models.py", line 1026, in raise_for_status
>     raise HTTPError(http_error_msg, response=self)
> requests.exceptions.HTTPError: 409 Client Error: Conflict for url: https://hosted.mender.io/api/management/v1/deployments/deployments/group/mender-docker-lifecycle-helper-example
> ```
> 
> ## Proposed resolution
> 
> Remove one source of the colliding deployment.
> 
> 