### PR TITLE
fix: support multi-platform images

### DIFF
--- a/src/mender_docker_lifecycle_helper/artifact.py
+++ b/src/mender_docker_lifecycle_helper/artifact.py
@@ -112,7 +112,9 @@ class LifecycleHelperArtifact:
         ]
         (artifact_image_prep_dir / DEEP_DELTA_FILENAME).touch()
         # Ensure images for delta are extracted in the cache
-        image_delta_file = self.context.image_cache.delta(previous_image, service_image)
+        image_delta_file = self.context.image_cache.delta(
+            previous_image, service_image, self.context.platform
+        )
         (artifact_image_prep_dir / IMAGE_FILE_NAME).symlink_to(image_delta_file)
         (artifact_image_prep_dir / "sums-current.txt").write_text(
             previous_image["hash"]

--- a/src/mender_docker_lifecycle_helper/utils/deep_delta.py
+++ b/src/mender_docker_lifecycle_helper/utils/deep_delta.py
@@ -20,12 +20,15 @@ class ImageDeltaException(Exception):
 
 
 def _read_layers_from_manifest(
-    image_dir: Path, logger: Optional[logging.Logger] = logging.getLogger(__name__)
+    image_dir: Path,
+    target_platform: str,
+    logger: Optional[logging.Logger] = logging.getLogger(__name__),
 ) -> list[Path]:
     """
     Reads the layers from an OCI image manifest file.
 
     :param image_dir: The directory in which the image is extracted.
+    :param target_platform: The platform to target, if the image contains multiple, as os/[architecture]/[variant].
     :param logger: A logger with which to log steps of function processes, defaults to logging.getLogger(__name__).
     :return: The list of paths to the layers referenced by the image manifest.
     """
@@ -44,6 +47,27 @@ def _read_layers_from_manifest(
     with open(blobs_dir / manifest_hash) as manifest_file:
         manifest = json.load(manifest_file)
 
+    # Multi-platform images may have multiple levels of manifests from the index.
+    if "layers" not in manifest and "manifests" in manifest:
+        logger.debug(
+            "Multi-platform image detected, looking for matching platform manifest..."
+        )
+        for platform_manifest in manifest["manifests"]:
+            platform_values = target_platform.split("/")
+            platform_fields = ["os", "architecture", "variant"]
+            if all(
+                platform_manifest["platform"].get(platform_field) == platform_value
+                for platform_field, platform_value in zip(
+                    platform_fields, platform_values
+                )
+            ):
+                logger.debug("Matching platform found!")
+                with open(
+                    blobs_dir
+                    / platform_manifest["digest"].removeprefix(f"{HASH_PREFIX}:")
+                ) as manifest_file:
+                    manifest = json.load(manifest_file)
+
     layers = [
         blobs_dir / layer["digest"].removeprefix(f"{HASH_PREFIX}:")
         for layer in manifest["layers"]
@@ -56,6 +80,7 @@ def oci_deep_delta(
     to_dir: Path,
     delta_dir: Path,
     delta_filename: str,
+    target_platform: str,
     delta_cmd: Optional[list[str]] = XDELTA_CMD,
     logger: Optional[logging.Logger] = logging.getLogger(__name__),
 ) -> Path:
@@ -69,15 +94,16 @@ def oci_deep_delta(
     :param delta_dir: The path under which to create the delta layers.
     :param delta_filename: The name of the delta image archive file to create.
     :param delta_cmd: The command to use for layer delta generation, defaults to XDELTA_CMD.
+    :param target_platform: The platform to target, if the image contains multiple, as os/[architecture]/[variant].
     :param logger: A logger with which to log steps of function processes, defaults to logging.getLogger(__name__).
     :raises ImageDeltaException: If images contain different numbers of layers.
     :return: The image delta file.
     """
     # Load layers from current image manifest
-    from_layers = _read_layers_from_manifest(from_dir)
+    from_layers = _read_layers_from_manifest(from_dir, target_platform, logger)
 
     # Load layers from new image manifest
-    to_layers = _read_layers_from_manifest(to_dir)
+    to_layers = _read_layers_from_manifest(to_dir, target_platform, logger)
 
     # Check if current image has more layers than new image
     if len(from_layers) > len(to_layers):

--- a/src/mender_docker_lifecycle_helper/utils/image_cache.py
+++ b/src/mender_docker_lifecycle_helper/utils/image_cache.py
@@ -75,12 +75,15 @@ class ImageCache:
             if hash_dir.is_dir()
         }
 
-    def delta(self, from_image: dict[str, str], to_image: dict[str, str]) -> Path:
+    def delta(
+        self, from_image: dict[str, str], to_image: dict[str, str], target_platform: str
+    ) -> Path:
         """
         Get the delta file path for a given from and to image hash, creating folders if required.
 
         :param from_image: The metadata (specifically {ref: <ref>, hash: <hash>}) of the image from which the delta is defined.
         :param to_image: The metadata (specifically {ref: <ref>, hash: <hash>}) of the image to which the delta is defined.
+        :param target_platform: The platform to target, if the image contains multiple, as os/[architecture]/[variant].
         :return: The path to the delta file for the given from and to image hash.
         """
         from_hash = from_image["hash"]
@@ -104,6 +107,8 @@ class ImageCache:
                 self.extract_cache_image(to_image),
                 delta_dir,
                 self.image_file_name,
+                target_platform,
+                logger=self.logger,
             )
             if from_hash not in self.delta_cache:
                 self.delta_cache[from_hash] = {}

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -45,7 +45,7 @@ class LifecycleHelperContextMock:
             version="0.1.0",
         )
         self.version = "1.0.0"
-
+        self.platform = "linux/amd64"
         self.delta = True
 
 
@@ -193,7 +193,7 @@ class TestPrepImages:
             version="1.0.0",
         )
         context_mock.logger = MagicMock()
-        context_mock.platform = "linux"
+        context_mock.platform = "linux/amd64"
         context_mock.cache_dir = tmp_path / "cache"
         context_mock.image_cache = MagicMock()
 
@@ -284,7 +284,7 @@ class TestPrepArtifactDir:
                 version="1.0.0",
             ),
             manifest_name="test",
-            platform="linux",
+            platform="linux/amd64",
             delta=True,
             manifest_file=(tmp_path / "docker-compose.yml"),
             manifest={"services": {"serviceA": {"image": "busybox:1.37.0-musl"}}},
@@ -320,8 +320,7 @@ class TestPrepArtifactDir:
             metadata = json.load(f)
         assert metadata["application_name"] == "test"
         assert metadata["orchestrator"] == "docker-compose"
-        assert metadata["platform"] == "linux"
-        assert metadata["version"] == "0.0.0"
+        assert metadata["platform"] == "linux/amd64"
         assert len(metadata["images"]) == 1
 
         # Verify images archive exists and has correct structure
@@ -374,7 +373,7 @@ class TestGenArtifact:
             manifest_name="test",
             manifest_file=(tmp_path / "docker-compose.yml"),
             manifest={"services": {"serviceA": {"image": "busybox:1.37.0-musl"}}},
-            platform="linux",
+            platform="linux/amd64",
             previous_artifact_metadata=SimpleNamespace(
                 version="1.0.0",
                 services={
@@ -435,7 +434,7 @@ class TestGenArtifact:
         ).read_text() == '{"payloads":[{"type":"app"}],"artifact_provides":{"artifact_name":"test"},"artifact_depends":{"device_type":["virtual"]}}'
         assert (
             header_extract_dir / "headers" / "0000" / "meta-data"
-        ).read_text() == '{"application_name":"test","images":["19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138"],"orchestrator":"docker-compose","platform":"linux","version":"2.0.0"}'
+        ).read_text() == '{"application_name":"test","images":["19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138"],"orchestrator":"docker-compose","platform":"linux/amd64","version":"2.0.0"}'
         assert (
             header_extract_dir / "headers" / "0000" / "type-info"
         ).read_text() == '{"type":"app","artifact_depends":{"rootfs-image.test.version":"1.0.0"},"artifact_provides":{"rootfs-image.test.version":"2.0.0"},"clears_artifact_provides":["rootfs-image.test.*"]}'
@@ -457,7 +456,7 @@ class TestGenArtifact:
                     }
                 }
             },
-            platform="linux",
+            platform="linux/amd64",
         )
         artifact_file = Path(tmp_path / "artifact1.mender")
         helper_artifact = LifecycleHelperArtifact(

--- a/tests/test_deep_delta.py
+++ b/tests/test_deep_delta.py
@@ -60,12 +60,204 @@ class TestReadLayersFromManifest:
             manifest_file.write_text(json.dumps(manifest_data))
 
             # Call function
-            layers = _read_layers_from_manifest(test_dir)
+            layers = _read_layers_from_manifest(test_dir, "linux/amd64")
 
             # Assertions
             assert len(layers) == 2
             assert layers[0] == blobs_dir / "layer1234567890abcdef"
             assert layers[1] == blobs_dir / "fedcba0987654321"
+
+    def test_read_layers_from_manifest_multi_platform(self):
+        """Test _read_layers_from_manifest handles multi-platform images correctly."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_dir = Path(tmp_dir) / "test-image"
+            blobs_dir = test_dir / "blobs" / "sha256"
+            blobs_dir.mkdir(parents=True)
+
+            # index.json points to an intermediate manifest (multi-platform index)
+            index_data = {
+                "schemaVersion": 2,
+                "manifests": [
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:intermediate_manifest",
+                    },
+                ],
+            }
+            index_file = test_dir / "index.json"
+            index_file.write_text(json.dumps(index_data))
+
+            # Intermediate manifest contains platform-specific manifests
+            intermediate_manifest = {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "manifests": [
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:manifest_amd64",
+                        "platform": {"os": "linux", "architecture": "amd64"},
+                    },
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:manifest_arm64",
+                        "platform": {"os": "linux", "architecture": "arm64"},
+                    },
+                ],
+            }
+            (blobs_dir / "intermediate_manifest").write_text(
+                json.dumps(intermediate_manifest)
+            )
+
+            amd64_manifest = {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "layers": [
+                    {
+                        "digest": "sha256:amd64_layer1",
+                        "size": 1000,
+                        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                    },
+                ],
+            }
+            (blobs_dir / "manifest_amd64").write_text(json.dumps(amd64_manifest))
+
+            arm64_manifest = {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "layers": [
+                    {
+                        "digest": "sha256:arm64_layer1",
+                        "size": 1000,
+                        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                    },
+                ],
+            }
+            (blobs_dir / "manifest_arm64").write_text(json.dumps(arm64_manifest))
+
+            layers = _read_layers_from_manifest(test_dir, "linux/amd64")
+            assert len(layers) == 1
+            assert layers[0] == blobs_dir / "amd64_layer1"
+
+            layers = _read_layers_from_manifest(test_dir, "linux/arm64")
+            assert len(layers) == 1
+            assert layers[0] == blobs_dir / "arm64_layer1"
+
+    def test_read_layers_from_manifest_multi_platform_with_variant(self):
+        """Test _read_layers_from_manifest handles multi-platform images with variant."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_dir = Path(tmp_dir) / "test-image"
+            blobs_dir = test_dir / "blobs" / "sha256"
+            blobs_dir.mkdir(parents=True)
+
+            # index.json points to an intermediate manifest (multi-platform index)
+            index_data = {
+                "schemaVersion": 2,
+                "manifests": [
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:intermediate_manifest",
+                    },
+                ],
+            }
+            index_file = test_dir / "index.json"
+            index_file.write_text(json.dumps(index_data))
+
+            # Intermediate manifest contains platform-specific manifests with variants
+            intermediate_manifest = {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "manifests": [
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:manifest_arm64_v8",
+                        "platform": {
+                            "os": "linux",
+                            "architecture": "arm64",
+                            "variant": "v8",
+                        },
+                    },
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:manifest_arm64_v7",
+                        "platform": {
+                            "os": "linux",
+                            "architecture": "arm64",
+                            "variant": "v7",
+                        },
+                    },
+                ],
+            }
+            (blobs_dir / "intermediate_manifest").write_text(
+                json.dumps(intermediate_manifest)
+            )
+
+            v8_manifest = {
+                "schemaVersion": 2,
+                "layers": [
+                    {
+                        "digest": "sha256:v8_layer1",
+                        "size": 1000,
+                        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                    },
+                ],
+            }
+            (blobs_dir / "manifest_arm64_v8").write_text(json.dumps(v8_manifest))
+
+            v7_manifest = {
+                "schemaVersion": 2,
+                "layers": [
+                    {
+                        "digest": "sha256:v7_layer1",
+                        "size": 1000,
+                        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                    },
+                ],
+            }
+            (blobs_dir / "manifest_arm64_v7").write_text(json.dumps(v7_manifest))
+
+            layers = _read_layers_from_manifest(test_dir, "linux/arm64/v8")
+            assert len(layers) == 1
+            assert layers[0] == blobs_dir / "v8_layer1"
+
+            layers = _read_layers_from_manifest(test_dir, "linux/arm64/v7")
+            assert len(layers) == 1
+            assert layers[0] == blobs_dir / "v7_layer1"
+
+    def test_read_layers_from_manifest_multi_platform_no_match(self):
+        """Test _read_layers_from_manifest uses first manifest if no platform match."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_dir = Path(tmp_dir) / "test-image"
+            blobs_dir = test_dir / "blobs" / "sha256"
+            blobs_dir.mkdir(parents=True)
+
+            index_data = {
+                "schemaVersion": 2,
+                "manifests": [
+                    {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:manifest_amd64",
+                        "platform": {"os": "linux", "architecture": "amd64"},
+                    },
+                ],
+            }
+            index_file = test_dir / "index.json"
+            index_file.write_text(json.dumps(index_data))
+
+            amd64_manifest = {
+                "schemaVersion": 2,
+                "layers": [
+                    {
+                        "digest": "sha256:amd64_layer1",
+                        "size": 1000,
+                        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                    },
+                ],
+            }
+            (blobs_dir / "manifest_amd64").write_text(json.dumps(amd64_manifest))
+
+            layers = _read_layers_from_manifest(test_dir, "linux/nonexistent")
+            assert len(layers) == 1
+            assert layers[0] == blobs_dir / "amd64_layer1"
 
 
 class TestOCIDeepDelta:
@@ -119,12 +311,13 @@ class TestOCIDeepDelta:
                 mock_tar_instance = MagicMock()
                 mock_tarfile.return_value.__enter__.return_value = mock_tar_instance
 
-                # Call function
-                delta_filename = "test-delta.tar"
-                result = oci_deep_delta(from_dir, to_dir, delta_dir, delta_filename)
+                result = oci_deep_delta(
+                    from_dir, to_dir, delta_dir, "test-delta.tar", "linux/amd64"
+                )
 
-                # Assertions
                 assert mock_read_layers.call_count == 2
+                for call in mock_read_layers.call_args_list:
+                    assert call[0][1] == "linux/amd64"
 
                 # Should call subprocess.run for each layer pair (2 calls since from_layers has 2 items)
                 assert mock_subprocess.call_count == 2
@@ -157,11 +350,12 @@ class TestOCIDeepDelta:
             from_dir = Path("/fake/from")
             to_dir = Path("/fake/to")
             delta_dir = Path("/fake/delta")
-            delta_filename = "test-delta.tar"
 
             # Should raise ImageDeltaException
             with pytest.raises(ImageDeltaException) as exc_info:
-                oci_deep_delta(from_dir, to_dir, delta_dir, delta_filename)
+                oci_deep_delta(
+                    from_dir, to_dir, delta_dir, "test-delta.tar", "linux/amd64"
+                )
 
             assert "source image has more layers than the new one" in str(
                 exc_info.value
@@ -208,9 +402,14 @@ class TestOCIDeepDelta:
                 error.stderr = "xdelta3 failed"
                 mock_subprocess.side_effect = error
 
-                # Should propagate the subprocess error
                 with pytest.raises(subprocess.SubprocessError) as exc_info:
-                    oci_deep_delta(from_dir, to_dir, delta_dir, "test-delta.tar")
+                    oci_deep_delta(
+                        from_dir,
+                        to_dir,
+                        delta_dir,
+                        "test-delta.tar",
+                        "linux/amd64",
+                    )
 
                 assert "xdelta3 failed" in str(exc_info.value)
 
@@ -268,7 +467,13 @@ class TestOCIDeepDelta:
 
                 # Should propagate the subprocess error via our manual check
                 with pytest.raises(subprocess.SubprocessError) as exc_info:
-                    oci_deep_delta(from_dir, to_dir, delta_dir, "test-delta.tar")
+                    oci_deep_delta(
+                        from_dir,
+                        to_dir,
+                        delta_dir,
+                        "test-delta.tar",
+                        "linux/amd64",
+                    )
 
                 assert "xdelta3 failed" in str(exc_info.value)
 
@@ -319,7 +524,8 @@ class TestOCIDeepDelta:
                     from_dir,
                     to_dir,
                     delta_dir,
-                    delta_filename,
+                    "test-delta.tar",
+                    "linux/amd64",
                     delta_cmd=custom_delta_cmd,
                 )
 
@@ -330,6 +536,9 @@ class TestOCIDeepDelta:
                 assert args[0][: len(custom_delta_cmd)] == custom_delta_cmd
                 assert kwargs["capture_output"] is True
                 assert kwargs["check"] is True
+
+                for call in mock_read_layers.call_args_list:
+                    assert call[0][1] == "linux/amd64"
 
 
 class TestDeepDeltaIntegration:
@@ -350,7 +559,7 @@ class TestDeepDeltaIntegration:
         # Generate delta file - this will pull images and extract them
         from_image = {"ref": "busybox:1.37.0-glibc", "hash": from_hash}
         to_image = {"ref": "busybox:1.37.0-musl", "hash": to_hash}
-        delta_file = cache.delta(from_image, to_image)
+        delta_file = cache.delta(from_image, to_image, "linux/amd64")
 
         # Verify delta file was created with correct contents
         extract_dir = tmp_path / "delta_extract"

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -111,7 +111,9 @@ class TestImageCacheDelta:
         cache = ImageCache(tmp_path)
 
         result = cache.delta(
-            {"ref": "from-image", "hash": "hash1"}, {"ref": "to-image", "hash": "hash2"}
+            {"ref": "from-image", "hash": "hash1"},
+            {"ref": "to-image", "hash": "hash2"},
+            "linux/amd64",
         )
         assert result == delta_file
 
@@ -134,12 +136,15 @@ class TestImageCacheDelta:
             mock_return_path = (
                 tmp_path / "delta" / "from_hash" / "to_hash" / "image.img"
             )
+            mock_return_path.parent.mkdir(parents=True)
+            mock_return_path.touch()
             mock_oci_deep_delta.return_value = mock_return_path
 
             # Call delta method
             result = cache.delta(
                 {"ref": "from-image", "hash": "from_hash"},
                 {"ref": "to-image", "hash": "to_hash"},
+                "linux/amd64",
             )
 
             # Verify oci_deep_delta was called with correct parameters
@@ -155,6 +160,7 @@ class TestImageCacheDelta:
 
             # Check that the fourth arg is the image file name
             assert args[3] == "image.img"
+            assert args[4] == "linux/amd64"
 
             # Verify the result is what we mocked
             assert result == mock_return_path
@@ -183,6 +189,7 @@ class TestImageCacheDelta:
             result1 = cache.delta(
                 {"ref": "from-image", "hash": "from_hash"},
                 {"ref": "to-image", "hash": "to_hash"},
+                "linux/amd64",
             )
             assert result1 == mock_return_path
             assert mock_oci.call_count == 1
@@ -191,6 +198,7 @@ class TestImageCacheDelta:
             result2 = cache.delta(
                 {"ref": "from-image", "hash": "from_hash"},
                 {"ref": "to-image", "hash": "to_hash"},
+                "linux/amd64",
             )
             assert result2 == mock_return_path
             assert mock_oci.call_count == 1
@@ -450,12 +458,12 @@ class TestImageCacheExtractCacheImage:
         )
 
         # Mock save_image_to_file to copy the dummy tar in place of pulling from docker
-        def mock_save_image_to_file(image_dict, save_file):
-            shutil.copy(tar_path, save_file)
+        def fake_save_image_to_file(image, file):
+            shutil.copy(tar_path, file)
 
         monkeypatch.setattr(
             "mender_docker_lifecycle_helper.utils.image_cache.save_image_to_file",
-            mock_save_image_to_file,
+            fake_save_image_to_file,
         )
 
         cache = ImageCache(tmp_path)


### PR DESCRIPTION
Closes #32 

> ## Expected behavior
> 
> Multi-platform images as input via `--service-file` or other specification should work.
> 
> ## Observed behavior
> 
> ```bash
>   File "/usr/local/lib/python3.12/site-packages/mender_docker_lifecycle_helper/utils/image_cache.py", line 102, in delta
>     delta_file = oci_deep_delta(
>                  ^^^^^^^^^^^^^^^
>   File "/usr/local/lib/python3.12/site-packages/mender_docker_lifecycle_helper/utils/deep_delta.py", line 77, in oci_deep_delta
>     from_layers = _read_layers_from_manifest(from_dir)
>                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/usr/local/lib/python3.12/site-packages/mender_docker_lifecycle_helper/utils/deep_delta.py", line 49, in _read_layers_from_manifest
>     for layer in manifest["layers"]
>                  ~~~~~~~~^^^^^^^^^^
> KeyError: 'layers'
> ```
> 
> ## Proposed resolution
> 
> More conditional handling of OCI manifest files for different structures.
> 