### PR TITLE
fix: strip ID sha prefix for image files

### DIFF
--- a/src/mender_docker_lifecycle_helper/utils/image_cache.py
+++ b/src/mender_docker_lifecycle_helper/utils/image_cache.py
@@ -6,7 +6,10 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
-from mender_docker_lifecycle_helper.utils.container_utils import save_image_to_file
+from mender_docker_lifecycle_helper.utils.container_utils import (
+    HASH_PREFIX,
+    save_image_to_file,
+)
 from mender_docker_lifecycle_helper.utils.deep_delta import oci_deep_delta
 
 DELTA_CACHE_DIRNAME = "delta"
@@ -165,6 +168,8 @@ class ImageCache:
                 "io.containerd.image.name", None
             )
             image_hash = image_manifest.get("digest", None)
+            if image_hash is not None:
+                image_hash = image_hash.removeprefix(f"{HASH_PREFIX}:")
             if image_ref is None:
                 raise ImageDirFormatException(
                     f"{extract_file} as extracted to {temp_extract_dir} does not contain expected io.containerd.image.name metadata in its index."

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -404,6 +404,32 @@ class TestImageCacheExtractCacheFile:
         save_image_path = tmp_path / "save" / "sha256content123" / "image.img"
         assert save_image_path.exists()
 
+    def test_extract_cache_file_strips_sha256_prefix(self, tmp_path):
+        """Test that sha256: prefix is stripped from digest in returned metadata and cache keys."""
+        tar_path = _create_oci_tar(
+            tmp_path, image_name="prefix-test-image", digest="sha256:abc123def"
+        )
+
+        cache = ImageCache(tmp_path)
+
+        result = cache.extract_cache_file(tar_path)
+
+        # Verify the sha256: prefix is stripped in the returned metadata
+        assert result["hash"] == "abc123def"
+        assert "sha256:" not in result["hash"]
+
+        # Verify the extract cache uses the stripped hash as key
+        assert "abc123def" in cache.extract_cache
+        assert cache.extract_cache["abc123def"].is_dir()
+
+        # Verify the save cache uses the stripped hash as key
+        assert "abc123def" in cache.save_cache
+        assert cache.save_cache["abc123def"].exists()
+
+        # Verify the actual directory names don't have the prefix
+        assert (tmp_path / "extract" / "abc123def").is_dir()
+        assert (tmp_path / "save" / "abc123def" / "image.img").exists()
+
 
 class TestImageCacheExtractCacheImage:
     """Tests for ImageCache.extract_cache_image method."""


### PR DESCRIPTION
Closes #34 

> ## Expected behavior
> 
> No image IDs should include the sha256: prefix.
> 
> ## Observed behavior
> 
> ```bash
> msg="Update Module output (stdout): images/sha256:69833584879f937f25ecd52838c8c202891a6a7a5db8454e665de9ae67e59ee9/image.img"
> ```
> 
> ## Proposed resolution
> 
> Strip the prefix from these images.
> 
